### PR TITLE
Removed unnecessary dependency for original-fs package

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,9 +40,7 @@ function hazardous (location) {
     unpacked = _cache[archive][fileName].unpacked;
   } else {
     try {
-      const fs = process.versions.electron
-        ? require ('original-fs')
-        : require ('fs');
+      const fs = require ('fs');
 
       unpacked = fs.existsSync (unpackedFilePath);
     } catch (ex) {


### PR DESCRIPTION
When including this package in my Electron project, I get an error trying to resolve "original-fs" on line 44:

```
const fs = process.versions.electron
     ? require ('original-fs')
     : require ('fs');
```

Looking at the package.json, I see that original-fs is not included as a dependency.  All this package does is wrap a require("fs") in a module.exports, which seems unnecessary.  I confirmed by modifying these lines to the following and it worked as expected.

```
const fs = require ('fs');
```